### PR TITLE
Add shared entries and reflections functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ A blockchain-based personal journal with built-in mindfulness prompts. Users can
 
 ## Features
 - Secure storage of encrypted journal entries
-- Daily mindfulness prompts
+- Daily mindfulness prompts 
 - Only entry owner can read their entries
 - Entry metadata is public but content is encrypted
+- Share entries publicly with the community
+- Add reflections to past entries
+- Community engagement through shared entries
 
 ## How it works
 1. Users can create new encrypted journal entries
@@ -14,3 +17,17 @@ A blockchain-based personal journal with built-in mindfulness prompts. Users can
 3. Entries are stored on-chain but encrypted
 4. Only the entry owner can decrypt and read their entries
 5. Basic metadata like timestamp and prompt ID are public
+6. Users can optionally share entries publicly
+7. Users can add reflections to their past entries
+8. Community members can read and engage with shared entries
+
+## New Features
+### Shared Entries
+- Users can choose to make entries public when creating them
+- Public entries are readable by all community members
+- Builds community engagement and support
+
+### Entry Reflections  
+- Add additional thoughts and reflections to past entries
+- Track how perspectives change over time
+- Deepen mindfulness practice through reflection


### PR DESCRIPTION
This PR adds two major new features to enhance user engagement and mindfulness practice:

### Shared Entries
- New boolean flag `is-shared` for entries
- New data map `shared-entries` to track public entries
- New function `get-shared-entry` to read public entries
- Updated `add-entry` to support sharing option
- Added tests for shared entry functionality

### Entry Reflections
- New optional `reflection` field for entries
- New function `add-reflection` to update past entries
- Users can add thoughts and insights to previous entries
- Added tests for reflection functionality

Benefits:
1. Enables community building through shared experiences
2. Deepens mindfulness practice via reflection
3. Creates opportunities for support and connection
4. Maintains privacy control - sharing is optional
5. Allows tracking of personal growth over time

All changes are backward compatible. Existing entries default to private with no reflection.